### PR TITLE
Specify release profile in fpm test and fpm run

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fix reference to fpm install in README
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Run the following command in the repository main directory:
 
 To check whether ATHENA has installed correctly and that the compilation works as expected, the following command can be run:
 ```
-  fpm test
+  fpm test --profile release
 ```
 
 This runs a set of test programs (found within the test/ directory) to ensure the expected output occurs when layers and networks are set up.
@@ -137,7 +137,7 @@ Using fpm, the examples are built alongside the library. To list all available e
 To run a particular example, execute the following command:
 
 ```
-  fpm run --example [NAME]
+  fpm run --example [NAME] --profile release
 ```
 
 where [_NAME_] is the name of the example found in the list.


### PR DESCRIPTION
Tiny change to the README to ensure tests and example are run in release mode with fpm.

A slightly confusing and not obvious default behavior of fpm is that if you don't specify profile, it defaults to "debug". So if you do:

```
fpm build --profile release  # this builds the library in the release mode
fpm test   # this builds the library in the debug mode and then runs the tests
```

you'll get two different builds and the tests will run in debug mode, but I don't think that was intended in the README. So this PR fixes that.